### PR TITLE
Update FiveM Serverlist API Link

### DIFF
--- a/servermodule.js
+++ b/servermodule.js
@@ -15,7 +15,7 @@ function LoadServerData(serverEndpoint){
     });
     
     // Get the server data for the specified serverAddress from the FiveM Serverlist.
-    $.getJSON("http://runtime.fivem.net/api/servers/", function(data){
+    $.getJSON("http://servers-live.fivem.net/api/servers/", function(data){
         for (var i = 0; i < data.length; i++){
             if(data[i]['EndPoint'] == serverAddress){
                 serverData = data[i];


### PR DESCRIPTION
The old link was: http://runtime.fivem.net/api/servers/ but after a couple of tests I saw that the Live URL is http://servers-live.fivem.net/api/servers/

Kind Regards and hope this help ;)